### PR TITLE
[UPLOAD] fix saving images close #83

### DIFF
--- a/upload/views.py
+++ b/upload/views.py
@@ -21,7 +21,7 @@ class UploadAPIView(APIView):
 
     def post(self, request, *args, **kwargs):
         # serializer
-        serializer = ImageSerializer(data=request.data, instance=request.user)  # handle incoming json requests
+        serializer = ImageSerializer(data=request.data)  # handle incoming json requests
 
         # request.FILES is a MultiValueDict
         files = request.FILES.getlist("image")   # .getlist("") to get multiple files
@@ -30,7 +30,7 @@ class UploadAPIView(APIView):
         if serializer.is_valid():
 
             # to do custom processing on the object before saving it
-            obj = serializer.save()
+            obj = serializer.save(user=request.user)
 
             # list with all the images present in the request
             images = [f for f in files]
@@ -43,7 +43,7 @@ class UploadAPIView(APIView):
             classification = Classification(images)
             obj.result = classification.use_template()
 
-            serializer.save()
+            serializer.save(user=request.user)
 
             return Response(obj.result, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
The setting of the `user=request.user` parameter was moved from `initialization` to `save` of serializer, because it did not allow the invocation of the `image_path(instance, filename)` method of `Image` class