### PR TITLE
[HISTORY] history method close #48

### DIFF
--- a/cat_photo/settings.py
+++ b/cat_photo/settings.py
@@ -58,7 +58,9 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.TokenAuthentication',
 
-    ]
+    ],
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 20  # number of images per page (for history view)
 }
 
 # where the uploaded image files will be saved and from which URL they can be served

--- a/cat_photo/urls.py
+++ b/cat_photo/urls.py
@@ -17,7 +17,9 @@ from django.contrib import admin
 from django.urls import path
 from account.views import SignupAPIView, LogoutAPIView
 from upload.views import UploadAPIView
-
+from history.views import ImageList  # , ImageUserView
+from django.conf import settings
+from django.conf.urls.static import static
 from rest_framework.authtoken.views import obtain_auth_token
 
 
@@ -31,5 +33,9 @@ urlpatterns = [
     path("login/", obtain_auth_token, name="login"),
     path("logout/", LogoutAPIView.as_view(), name="logout"),
     path("upload/", UploadAPIView.as_view(), name="upload"),
+    path("history/", ImageList.as_view(), name="history"),
+    # path("history2/", ImageUserView.as_view(), name="history2"),
 
 ]
+# To make the URLs of the images accessible.
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/history/views.py
+++ b/history/views.py
@@ -1,3 +1,25 @@
-from django.shortcuts import render
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework import generics
 
-# Create your views here.
+from upload.models import Image
+from upload.serializers import ImageSerializer
+
+
+class ImageList(generics.ListAPIView):
+    # from https://www.django-rest-framework.org/api-guide/filtering/
+
+    # Specify what authentication to use
+    authentication_classes = [TokenAuthentication]  # Requires token authentication
+    # Will deny permission to any unauthenticated user, and allow permission otherwise
+    permission_classes = [IsAuthenticated]
+
+    serializer_class = ImageSerializer
+
+    def get_queryset(self):
+        """
+        This view should return a list of all the images
+        for the currently authenticated user.
+        """
+        user = self.request.user
+        return Image.objects.filter(user=user)


### PR DESCRIPTION
This solution on the "history" route will return the list of images of a certain user.
Each element of this list will contain:

-      "result" = the result of the image classification
-      "user" = user id
-      "image" = the url of the image (*)

    
(*) Note: for now the urls are related to the back end server, where the images currently reside.

Furthermore, the results, thanks to pagination, can be divided by a certain number of images per page (20 has been set by default).
Therefore each Response will also contain the following fields:

-      "count" = the total number of images of that particular user
-      "next": the url to the next page
-      "previous": the url to the previous page



Example:
Upon receipt of the request, containing (in the Header) the Token of a connected user, 
Request with parameters:

-     limit  = number of images per page 
-     offset = the number of the first image

`http://127.0.0.1:8000/history/?limit=20&offset=40`

the following response will be returned:
Response:
```
{
    "count": 63,
    "next": "http://127.0.0.1:8000/history/?limit=3&offset=61",
    "previous": "http://127.0.0.1:8000/history/?limit=3&offset=55",
    "results": [
    # 1
        {
            "result": "(True, {0: ('viaduct', 50.96623992919922)})",
            "user": 4,
            "image": "http://127.0.0.1:8000/media/user-image/4/13-04-2021-13-06-20.jpg"
        },
    # 2
        {
            "result": "(True, {0: ('viaduct', 50.96623992919922)})",
            "user": 4,
            "image": "http://127.0.0.1:8000/media/user-image/4/13-04-2021-13-10-35.jpg"
        },
        
    #  .
    #  .
    #  .
    
    # 20        
        {
            "result": "(True, {0: ('viaduct', 50.96623992919922)})",
            "user": 4,
            "image": "http://127.0.0.1:8000/media/user-image/4/13-04-2021-13-13-24.jpg"
        }
    ]
}

```
